### PR TITLE
Add second test post to verify duplicate prevention system

### DIFF
--- a/posts/testing-duplicate-prevention-system.md
+++ b/posts/testing-duplicate-prevention-system.md
@@ -1,0 +1,53 @@
+---
+title: Testing Duplicate Prevention System
+description: Second test post to verify that duplicate Bluesky posts are properly prevented
+date: 2025-09-17
+tags:
+  - test
+  - bluesky
+  - duplicate-prevention
+layout: layouts/post.njk
+---
+
+This is the **second test post** to verify that our duplicate prevention system is working correctly! 🛡️
+
+## What Should Happen
+
+When this post is published:
+
+1. ✅ **This post should appear on Bluesky** (it's new)
+2. ❌ **The first test post should NOT be posted again** (it's already tracked)
+3. 📝 **The tracking file should be updated** with this post's filename
+
+Expected Bluesky post:
+```
+📝 New blog post: Testing Duplicate Prevention System
+
+Second test post to verify that duplicate Bluesky posts are properly prevented
+
+🔗 https://ronnie.fyi/posts/testing-duplicate-prevention-system/
+```
+
+## How The System Works
+
+The new duplicate prevention system:
+
+- **Tracks specific filenames** in `.bluesky-posted.json`
+- **Only posts files that haven't been posted before**
+- **Marks files as posted only after successful posting**
+- **Persists state between GitHub Actions runs**
+
+This means you can safely:
+- Re-run GitHub Actions workflows
+- Push multiple times
+- Make changes to existing posts
+
+Without worrying about flooding your Bluesky feed with duplicates!
+
+## Testing Results
+
+If you're reading this on Bluesky and you **didn't** see a duplicate of the first "Testing Bluesky Integration" post, then our duplicate prevention system is working perfectly! 🎉
+
+---
+
+*This is a test post and can be deleted once the duplicate prevention system is confirmed to be working.*


### PR DESCRIPTION
This test will verify that:
- New posts are still posted to Bluesky with clickable links
- Previous test post is NOT posted again (duplicate prevention)
- Tracking system properly updates .bluesky-posted.json

Expected behavior:
- Only this new post should appear on Bluesky
- First test post should remain in tracking file
- This post should be added to tracking file after successful posting

Expected Bluesky post format:
📝 New blog post: Testing Duplicate Prevention System Second test post to verify that duplicate Bluesky posts are properly prevented 🔗 https://ronnie.fyi/posts/testing-duplicate-prevention-system/ (clickable)