### PR TITLE
Add dynamic timestamp updates for Spotify integration

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,6 +22,23 @@ module.exports = function (eleventyConfig) {
         return DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat("dd LLL yyyy");
     });
 
+    // Format timestamp for "last updated" displays
+    eleventyConfig.addFilter("relativeTime", dateStr => {
+        const date = DateTime.fromISO(dateStr);
+        const now = DateTime.now();
+        const diff = now.diff(date, ['hours', 'minutes']).toObject();
+        
+        if (diff.hours >= 24) {
+            return date.toFormat("dd LLL");
+        } else if (diff.hours >= 1) {
+            return `${Math.floor(diff.hours)}h ago`;
+        } else if (diff.minutes >= 1) {
+            return `${Math.floor(diff.minutes)}m ago`;
+        } else {
+            return 'just now';
+        }
+    });
+
     // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
     eleventyConfig.addFilter('htmlDateString', (dateObj) => {
         return DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat('yyyy-LL-dd');
@@ -63,6 +80,7 @@ module.exports = function (eleventyConfig) {
     // Copy the `img` and `css` folders to the output
     eleventyConfig.addPassthroughCopy("img");
     eleventyConfig.addPassthroughCopy("css");
+    eleventyConfig.addPassthroughCopy("js");
     eleventyConfig.addPassthroughCopy(".well-known");
 
     // Customize Markdown library and settings:

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -48,6 +48,7 @@
 
     <footer></footer>
 
+    <script src="{{ '/js/relative-time.js' | url }}"></script>
     <!-- Current page: {{ page.url | url }} -->
   </body>
 </html>

--- a/index.njk
+++ b/index.njk
@@ -13,14 +13,28 @@ eleventyNavigation:
 
 <p>More posts can be found in <a href="{{ '/posts/' | url }}">the archive</a>.</p>
 
-{% if currentTrack.song and currentTrack.artist %}
+{% if currentTrack.current and currentTrack.current.song and currentTrack.current.artist %}
 <p class="current-listening">
   I'm currently listening to 
-  {% if currentTrack.url and not currentTrack.error %}
-    <a href="{{ currentTrack.url }}" target="_blank" rel="noopener noreferrer">{{ currentTrack.song }}</a>
+  {% if currentTrack.current.url and not currentTrack.error %}
+    <a href="{{ currentTrack.current.url }}" target="_blank" rel="noopener noreferrer">{{ currentTrack.current.song }}</a>
   {% else %}
-    {{ currentTrack.song }}
+    {{ currentTrack.current.song }}
   {% endif %}
-  by <strong>{{ currentTrack.artist }}</strong>.
+  by <strong>{{ currentTrack.current.artist }}</strong>{% if currentTrack.current.playedAt %} <small>(<span class="relative-time" data-played-at="{{ currentTrack.current.playedAt }}">{{ currentTrack.current.playedAt | relativeTime }}</span>)</small>{% endif %}.
 </p>
+
+{% if currentTrack.recent and currentTrack.recent.length > 0 %}
+<details class="recently-played">
+  <summary>Recently played tracks</summary>
+  <ul class="track-list">
+    {% for track in currentTrack.recent %}
+    <li class="track-item">
+      <a href="{{ track.url }}" target="_blank" rel="noopener noreferrer">{{ track.song }}</a>
+      by {{ track.artist }}
+    </li>
+    {% endfor %}
+  </ul>
+</details>
+{% endif %}
 {% endif %}

--- a/js/relative-time.js
+++ b/js/relative-time.js
@@ -1,0 +1,41 @@
+/**
+ * Updates relative time displays dynamically in the browser
+ */
+function updateRelativeTime() {
+    const elements = document.querySelectorAll('.relative-time[data-played-at]');
+    
+    elements.forEach(element => {
+        const playedAt = new Date(element.dataset.playedAt);
+        const now = new Date();
+        const diffMs = now - playedAt;
+        
+        // Convert to minutes and hours
+        const minutes = Math.floor(diffMs / 60000);
+        const hours = Math.floor(minutes / 60);
+        const days = Math.floor(hours / 24);
+        
+        let relativeText;
+        
+        if (days >= 1) {
+            // Show date format for anything older than 24 hours
+            relativeText = playedAt.toLocaleDateString('en-GB', { 
+                day: 'numeric', 
+                month: 'short' 
+            });
+        } else if (hours >= 1) {
+            relativeText = `${hours}h ago`;
+        } else if (minutes >= 1) {
+            relativeText = `${minutes}m ago`;
+        } else {
+            relativeText = 'just now';
+        }
+        
+        element.textContent = relativeText;
+    });
+}
+
+// Update on page load
+document.addEventListener('DOMContentLoaded', updateRelativeTime);
+
+// Update every minute to keep timestamps fresh
+setInterval(updateRelativeTime, 60000);

--- a/scripts/spotify-current-track.js
+++ b/scripts/spotify-current-track.js
@@ -73,7 +73,7 @@ async function getCurrentTrack() {
     const options = {
       hostname: 'api.spotify.com',
       port: 443,
-      path: '/v1/me/player/recently-played?limit=1',
+      path: '/v1/me/player/recently-played?limit=10', // Get 10 recent tracks
       method: 'GET',
       headers: {
         'Authorization': `Bearer ${accessToken}`
@@ -87,41 +87,52 @@ async function getCurrentTrack() {
     }
     
     if (response.data.items && response.data.items.length > 0) {
-      const track = response.data.items[0].track;
+      const tracks = response.data.items.map(item => ({
+        song: item.track.name,
+        artist: item.track.artists.map(artist => artist.name).join(', '),
+        url: item.track.external_urls.spotify,
+        album: item.track.album.name,
+        playedAt: item.played_at
+      }));
+
+      // Return structured data with current track and recent tracks
       return {
-        song: track.name,
-        artist: track.artists.map(artist => artist.name).join(', '),
-        url: track.external_urls.spotify,
+        current: tracks[0], // Most recent track
+        recent: tracks.slice(1, 6), // Next 5 tracks for "recently played"
         timestamp: new Date().toISOString()
       };
     }
     
     return null;
   } catch (error) {
-    console.error('Error fetching current track:', error);
+    console.error('Error fetching tracks:', error);
     return null;
   }
 }
 
 async function updateCurrentTrack() {
-  const currentTrack = await getCurrentTrack();
+  const trackData = await getCurrentTrack();
   
   const dataPath = path.join(__dirname, '..', '_data', 'currentTrack.json');
   
-  if (currentTrack) {
-    fs.writeFileSync(dataPath, JSON.stringify(currentTrack, null, 2));
-    console.log(`Updated current track: ${currentTrack.song} by ${currentTrack.artist}`);
+  if (trackData && trackData.current) {
+    fs.writeFileSync(dataPath, JSON.stringify(trackData, null, 2));
+    console.log(`Updated current track: ${trackData.current.song} by ${trackData.current.artist}`);
+    console.log(`Also fetched ${trackData.recent.length} recently played tracks`);
   } else {
     // Fallback data if API fails
     const fallbackData = {
-      song: "Unknown",
-      artist: "Unknown Artist",
-      url: "https://open.spotify.com",
+      current: {
+        song: "Unknown",
+        artist: "Unknown Artist",
+        url: "https://open.spotify.com"
+      },
+      recent: [],
       timestamp: new Date().toISOString(),
       error: true
     };
     fs.writeFileSync(dataPath, JSON.stringify(fallbackData, null, 2));
-    console.log('Failed to fetch current track, using fallback');
+    console.log('Failed to fetch tracks, using fallback');
   }
 }
 


### PR DESCRIPTION
- Add client-side JavaScript for real-time timestamp calculation
- Add relativeTime filter to Eleventy with server-side fallback
- Enhance Spotify integration with recently played tracks display
- Update templates to use data attributes for dynamic timestamps
- Add js/ directory to Eleventy passthrough for client-side scripts

Timestamps now update every minute in the browser instead of being static from build time, providing accurate 'played X minutes ago' regardless of when the page was last built.