### PR TITLE
Add automatic post ordering by file creation time + new blog post

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -77,6 +77,20 @@ module.exports = function (eleventyConfig) {
         return filterTagList([...tagSet]);
     });
 
+    // Create posts collection sorted by file creation time
+    eleventyConfig.addCollection("posts", function (collection) {
+        const fs = require("fs");
+        return collection.getFilteredByTag("posts").sort(function (a, b) {
+            // Get file creation times (birthtime) or fall back to modification time
+            const aTime = fs.statSync(a.inputPath).birthtime || fs.statSync(a.inputPath).mtime;
+            const bTime = fs.statSync(b.inputPath).birthtime || fs.statSync(b.inputPath).mtime;
+            
+            // Sort by creation time (oldest first, so newest end up at the end)
+            // This works with head(-6) and | reverse to show newest first
+            return aTime - bTime;
+        });
+    });
+
     // Copy the `img` and `css` folders to the output
     eleventyConfig.addPassthroughCopy("img");
     eleventyConfig.addPassthroughCopy("css");

--- a/posts/world-war-2-is-my-roman-empire.md
+++ b/posts/world-war-2-is-my-roman-empire.md
@@ -1,0 +1,36 @@
+---
+title: The World War 2 Universe
+description: You must just reach an age where you start deep-diving into WW2 movies
+date: 2025-09-17
+tags:
+  - media
+layout: layouts/post.njk
+---
+
+## World War 2 is my Roman Empire
+
+"Women have no idea how often the men in their lives think about the Roman Empire".
+
+Or, so the meme goes. 
+
+I watched a couple of World War 2 movies recently and fell into a bit of a rabbit hole. I assume it's my age.
+
+### Recent media diet
+
+- [Ghosts](https://en.wikipedia.org/wiki/Ghosts_(2019_TV_series)) ⭐️⭐️⭐️⭐️
+- [Slow Horses](https://en.wikipedia.org/wiki/Slow_Horses) ⭐️⭐️⭐️⭐️
+- [Adolescence](https://en.wikipedia.org/wiki/Adolescence_(TV_series)) ⭐️⭐️⭐️⭐️⭐️
+- [Wonka](https://en.wikipedia.org/wiki/Wonka_(film)) ⭐️⭐️⭐️
+- [Dunkirk](https://en.wikipedia.org/wiki/Dunkirk_(2017_film)) ⭐️⭐️⭐️
+- [Darkest Hour](https://en.wikipedia.org/wiki/Darkest_Hour_(film)) ⭐️⭐️
+- [Hitler: The Rise of Evil](https://en.wikipedia.org/wiki/Hitler:_The_Rise_of_Evil) ⭐️
+
+While watching Dunkirk and Darkest Hour I realised both movies are about the same subject; [the rescue mission to save around 300,000 soldiers from the beach at Dunkirk](https://en.wikipedia.org/wiki/Dunkirk_evacuation). In the case of Darkest Hour, Gary Oldman (as Winston Churchill) is at the centre of the story as the British government scramble to pull together a workable plan, and then put it in place.
+
+Anyway, when I realised this, I thought, "I wonder if someone's created a list of World War 2 movies, and the chronological order in which to watch them, in the same way that people have done for Star Wars and the Marvel Universe?
+
+[Well, they have. I found it on Reddit](https://www.reddit.com/r/movies/comments/15klf3p/ive_made_a_list_of_ww2_movies_and_put_them_in/).
+
+As a result, I've also watched Part 1 of Hitler: The Rise of Evil, featuring Robert Carlyle as a young Adolf. It's always odd to see actors voicing what we know are German people, with US accents. 
+
+I can't say that I recommend it.


### PR DESCRIPTION
- Add custom posts collection that sorts by file birthtime/creation time
- Eliminates need for manual timestamps when posts have same date
- Posts now automatically appear in chronological order based on when files were created
- Works seamlessly with existing head(-6) and reverse template logic
- Most recently created posts appear first on home page

New post: 'World War 2 is my Roman Empire' - thoughts on diving deep into WW2 movies and content