### PR TITLE
Change Contentful posts URL structure from /contentful-posts/ to /posts/

### DIFF
--- a/_data/contentfulPosts.js
+++ b/_data/contentfulPosts.js
@@ -39,9 +39,9 @@ module.exports = async function() {
         tags: fields.tags || [],
         content: content,
         featured: fields.featured || false,
-        // Eleventy expects these for compatibility - using different URL pattern to avoid conflicts
-        url: `/contentful-posts/${fields.slug}/`,
-        inputPath: `./contentful-posts/${fields.slug}.md`, // Virtual path for compatibility
+        // Eleventy expects these for compatibility - using /posts/ URL pattern
+        url: `/posts/${fields.slug}/`,
+        inputPath: `./posts/${fields.slug}.md`, // Virtual path for compatibility
         data: {
           title: fields.title,
           description: fields.description,

--- a/archive.njk
+++ b/archive.njk
@@ -21,7 +21,7 @@ eleventyNavigation:
 {# Add Contentful posts to allPosts array #}
 {% for post in contentfulPostsData %}
   {% set contentfulPost = {
-    url: "/contentful-posts/" + post.slug + "/",
+    url: "/posts/" + post.slug + "/",
     data: {
       title: post.title,
       date: post.date

--- a/contentful-posts.njk
+++ b/contentful-posts.njk
@@ -4,7 +4,7 @@ pagination:
   data: contentfulPosts
   size: 1
   alias: post
-permalink: "/contentful-posts/{{ post.slug }}/"
+permalink: "/posts/{{ post.slug }}/"
 eleventyComputed:
   title: "{{ post.title }}"
   description: "{{ post.description }}"

--- a/index.njk
+++ b/index.njk
@@ -17,7 +17,7 @@ eleventyNavigation:
 {# Add Contentful posts to allPosts array #}
 {% for post in contentfulPostsData %}
   {% set contentfulPost = {
-    url: "/contentful-posts/" + post.slug + "/",
+    url: "/posts/" + post.slug + "/",
     data: {
       title: post.title,
       date: post.date

--- a/scripts/bluesky-post.js
+++ b/scripts/bluesky-post.js
@@ -160,7 +160,7 @@ async function detectNewContentfulPosts() {
         title: item.fields.title,
         slug: item.fields.slug,
         description: item.fields.description || '',
-        url: `${SITE_URL}/contentful-posts/${item.fields.slug}/`,
+        url: `${SITE_URL}/posts/${item.fields.slug}/`,
         filename: postId,
         source: 'contentful'
       };


### PR DESCRIPTION
- Update permalink in contentful-posts.njk template
- Update URL generation in Bluesky posting script
- Update URL references in archive.njk and index.njk
- Update URL generation in _data/contentfulPosts.js
- This creates a cleaner, more standard URL structure for blog posts