### PR TITLE
📅 Reorganize archive page by year and month

### DIFF
--- a/archive.njk
+++ b/archive.njk
@@ -38,64 +38,51 @@ eleventyNavigation:
 {# Sort all posts by date (newest first) #}
 {% set sortedPosts = allPosts | sort(false, false, 'date') %}
 
-{# Display posts grouped by year and month #}
-{% set displayedYearMonth = [] %}
+{# Group posts by year-month combination in a single pass #}
+{% set groupedPosts = [] %}
 {% set monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] %}
+{% set lastCombo = null %}
 
-{# First pass: collect all unique year-month combinations #}
-{% set yearMonthCombos = [] %}
 {% for post in sortedPosts %}
   {% set postDate = post.date or post.data.date %}
   {% set year = postDate.getFullYear() %}
   {% set month = postDate.getMonth() %}
   {% set combo = year * 100 + month %}
+  {% set monthName = monthNames[month] %}
   
-  {% set found = false %}
-  {% for existingCombo in yearMonthCombos %}
-    {% if existingCombo == combo %}
-      {% set found = true %}
-    {% endif %}
-  {% endfor %}
-  
-  {% if not found %}
-    {% set yearMonthCombos = (yearMonthCombos.push(combo), yearMonthCombos) %}
+  {# Check if this is a new year-month combination #}
+  {% if combo != lastCombo %}
+    {# Create new group for this combination #}
+    {% set newGroup = {
+      combo: combo,
+      year: year,
+      month: month,
+      monthName: monthName,
+      posts: [post]
+    } %}
+    {% set groupedPosts = (groupedPosts.push(newGroup), groupedPosts) %}
+    {% set lastCombo = combo %}
+  {% else %}
+    {# Add to existing group (the last one in the array) #}
+    {% set currentGroup = groupedPosts[groupedPosts.length - 1] %}
+    {% set currentGroup.posts = (currentGroup.posts.push(post), currentGroup.posts) %}
   {% endif %}
 {% endfor %}
 
-{# Sort combinations in descending order (newest first) #}
-{% set sortedCombos = yearMonthCombos | sort | reverse %}
-
-{# Display each year-month combination #}
+{# Display each group (already in newest-first order) #}
 {% set currentDisplayYear = null %}
-{% for combo in sortedCombos %}
-  {% set year = (combo / 100) | round(0, "floor") %}
-  {% set month = combo % 100 %}
-  {% set monthName = monthNames[month] %}
-  
+{% for group in groupedPosts %}
   {# Show year header if this is a new year #}
-  {% if year != currentDisplayYear %}
-    <h2 class="archive-year">{{ year }}</h2>
-    {% set currentDisplayYear = year %}
+  {% if group.year != currentDisplayYear %}
+    <h2 class="archive-year">{{ group.year }}</h2>
+    {% set currentDisplayYear = group.year %}
   {% endif %}
   
-  {# Show month header #}
-  <h3 class="archive-month">{{ monthName }}</h3>
+  {# Show month header and posts #}
+  <h3 class="archive-month">{{ group.monthName }}</h3>
   <ul class="archive-posts">
-    
-    {# Collect all posts for this year-month combination #}
-    {% set monthPosts = [] %}
-    {% for post in sortedPosts %}
-      {% set postDate = post.date or post.data.date %}
-      {% set postYear = postDate.getFullYear() %}
-      {% set postMonth = postDate.getMonth() %}
-      
-      {% if postYear == year and postMonth == month %}
-        {% set monthPosts = (monthPosts.push(post), monthPosts) %}
-      {% endif %}
-    {% endfor %}
-    
-    {# Sort this month's posts by date (newest first) and display them #}
-    {% for post in (monthPosts | sort(false, false, 'date') | reverse) %}
+    {# Display the month's posts (already in newest-first order) #}
+    {% for post in group.posts %}
       {% set postDate = post.date or post.data.date %}
       <li class="archive-post-item">
         <a href="{{ post.url | url }}" class="archive-post-link">
@@ -106,6 +93,5 @@ eleventyNavigation:
         </time>
       </li>
     {% endfor %}
-    
   </ul>
 {% endfor %}

--- a/archive.njk
+++ b/archive.njk
@@ -46,7 +46,6 @@ eleventyNavigation:
 {# Simple grouped display using array approach #}
 {% set currentYear = null %}
 {% set currentMonth = null %}
-{% set monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] %}
 
 {% for post in sortedPosts %}
   {% set postDate = post.date or post.data.date %}

--- a/archive.njk
+++ b/archive.njk
@@ -55,7 +55,6 @@ eleventyNavigation:
     
     {# Check if we need a new year header #}
     {% if year != currentYear %}
-      {% if currentYear != null %}</ul>{% endif %}
       <h2 class="archive-year">{{ year }}</h2>
       {% set currentYear = year %}
       {% set currentMonth = null %}

--- a/archive.njk
+++ b/archive.njk
@@ -24,14 +24,88 @@ eleventyNavigation:
     url: "/posts/" + post.slug + "/",
     data: {
       title: post.title,
-      date: post.date
+      date: post.date,
+      description: post.description
     },
     date: post.date,
-    title: post.title
+    title: post.title,
+    description: post.description,
+    featured: post.featured
   } %}
   {% set allPosts = (allPosts.push(contentfulPost), allPosts) %}
 {% endfor %}
 
 {# Sort all posts by date (newest first) #}
-{% set postslist = allPosts | sort(false, false, 'date') %}
-{% include "postslist.njk" %}
+{% set sortedPosts = allPosts | sort(false, false, 'date') %}
+
+{# Display posts grouped by year and month #}
+{% set displayedYearMonth = [] %}
+{% set monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] %}
+
+{# First pass: collect all unique year-month combinations #}
+{% set yearMonthCombos = [] %}
+{% for post in sortedPosts %}
+  {% set postDate = post.date or post.data.date %}
+  {% set year = postDate.getFullYear() %}
+  {% set month = postDate.getMonth() %}
+  {% set combo = year * 100 + month %}
+  
+  {% set found = false %}
+  {% for existingCombo in yearMonthCombos %}
+    {% if existingCombo == combo %}
+      {% set found = true %}
+    {% endif %}
+  {% endfor %}
+  
+  {% if not found %}
+    {% set yearMonthCombos = (yearMonthCombos.push(combo), yearMonthCombos) %}
+  {% endif %}
+{% endfor %}
+
+{# Sort combinations in descending order (newest first) #}
+{% set sortedCombos = yearMonthCombos | sort | reverse %}
+
+{# Display each year-month combination #}
+{% set currentDisplayYear = null %}
+{% for combo in sortedCombos %}
+  {% set year = (combo / 100) | round(0, "floor") %}
+  {% set month = combo % 100 %}
+  {% set monthName = monthNames[month] %}
+  
+  {# Show year header if this is a new year #}
+  {% if year != currentDisplayYear %}
+    <h2 class="archive-year">{{ year }}</h2>
+    {% set currentDisplayYear = year %}
+  {% endif %}
+  
+  {# Show month header #}
+  <h3 class="archive-month">{{ monthName }}</h3>
+  <ul class="archive-posts">
+    
+    {# Collect all posts for this year-month combination #}
+    {% set monthPosts = [] %}
+    {% for post in sortedPosts %}
+      {% set postDate = post.date or post.data.date %}
+      {% set postYear = postDate.getFullYear() %}
+      {% set postMonth = postDate.getMonth() %}
+      
+      {% if postYear == year and postMonth == month %}
+        {% set monthPosts = (monthPosts.push(post), monthPosts) %}
+      {% endif %}
+    {% endfor %}
+    
+    {# Sort this month's posts by date (newest first) and display them #}
+    {% for post in (monthPosts | sort(false, false, 'date') | reverse) %}
+      {% set postDate = post.date or post.data.date %}
+      <li class="archive-post-item">
+        <a href="{{ post.url | url }}" class="archive-post-link">
+          {% if post.title %}{{ post.title }}{% elif post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}
+        </a>
+        <time class="archive-post-date" datetime="{{ postDate | htmlDateString }}">
+          {{ postDate | readableDate }}
+        </time>
+      </li>
+    {% endfor %}
+    
+  </ul>
+{% endfor %}

--- a/archive.njk
+++ b/archive.njk
@@ -20,78 +20,65 @@ eleventyNavigation:
 
 {# Add Contentful posts to allPosts array #}
 {% for post in contentfulPostsData %}
-  {% set contentfulPost = {
-    url: "/posts/" + post.slug + "/",
-    data: {
-      title: post.title,
+  {% if post.slug %}
+    {% set contentfulPost = {
+      url: "/posts/" + post.slug + "/",
+      data: {
+        title: post.title,
+        date: post.date,
+        description: post.description
+      },
       date: post.date,
-      description: post.description
-    },
-    date: post.date,
-    title: post.title,
-    description: post.description,
-    featured: post.featured
-  } %}
-  {% set allPosts = (allPosts.push(contentfulPost), allPosts) %}
+      title: post.title,
+      description: post.description,
+      featured: post.featured
+    } %}
+    {% set allPosts = (allPosts.push(contentfulPost), allPosts) %}
+  {% endif %}
 {% endfor %}
 
 {# Sort all posts by date (newest first) #}
 {% set sortedPosts = allPosts | sort(false, false, 'date') %}
 
-{# Group posts by year-month combination in a single pass #}
-{% set groupedPosts = [] %}
+{# Month names array - make sure we have 12 elements (index 0-11) #}
 {% set monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] %}
-{% set lastCombo = null %}
+
+{# Simple grouped display using array approach #}
+{% set currentYear = null %}
+{% set currentMonth = null %}
+{% set monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] %}
 
 {% for post in sortedPosts %}
   {% set postDate = post.date or post.data.date %}
-  {% set year = postDate.getFullYear() %}
-  {% set month = postDate.getMonth() %}
-  {% set combo = year * 100 + month %}
-  {% set monthName = monthNames[month] %}
-  
-  {# Check if this is a new year-month combination #}
-  {% if combo != lastCombo %}
-    {# Create new group for this combination #}
-    {% set newGroup = {
-      combo: combo,
-      year: year,
-      month: month,
-      monthName: monthName,
-      posts: [post]
-    } %}
-    {% set groupedPosts = (groupedPosts.push(newGroup), groupedPosts) %}
-    {% set lastCombo = combo %}
-  {% else %}
-    {# Add to existing group (the last one in the array) #}
-    {% set currentGroup = groupedPosts[groupedPosts.length - 1] %}
-    {% set currentGroup.posts = (currentGroup.posts.push(post), currentGroup.posts) %}
+  {% if postDate %}
+    {% set year = postDate.getFullYear() %}
+    {% set month = postDate.getMonth() %}
+    
+    {# Check if we need a new year header #}
+    {% if year != currentYear %}
+      {% if currentYear != null %}</ul>{% endif %}
+      <h2 class="archive-year">{{ year }}</h2>
+      {% set currentYear = year %}
+      {% set currentMonth = null %}
+    {% endif %}
+    
+    {# Check if we need a new month header #}
+    {% if month != currentMonth %}
+      {% if currentMonth != null %}</ul>{% endif %}
+      <h3 class="archive-month">{{ monthNames[month] }}</h3>
+      <ul class="archive-posts">
+      {% set currentMonth = month %}
+    {% endif %}
+    
+    {# Display the post using the same pattern as postslist.njk #}
+    <li class="archive-post-item">
+      <a href="{{ post.url | url }}" class="archive-post-link">
+        {% if post.title %}{{ post.title }}{% elif post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}
+      </a>
+      <time class="archive-post-date" datetime="{{ postDate | htmlDateString }}">
+        {{ postDate | readableDate }}
+      </time>
+    </li>
   {% endif %}
 {% endfor %}
-
-{# Display each group (already in newest-first order) #}
-{% set currentDisplayYear = null %}
-{% for group in groupedPosts %}
-  {# Show year header if this is a new year #}
-  {% if group.year != currentDisplayYear %}
-    <h2 class="archive-year">{{ group.year }}</h2>
-    {% set currentDisplayYear = group.year %}
-  {% endif %}
-  
-  {# Show month header and posts #}
-  <h3 class="archive-month">{{ group.monthName }}</h3>
-  <ul class="archive-posts">
-    {# Display the month's posts (already in newest-first order) #}
-    {% for post in group.posts %}
-      {% set postDate = post.date or post.data.date %}
-      <li class="archive-post-item">
-        <a href="{{ post.url | url }}" class="archive-post-link">
-          {% if post.title %}{{ post.title }}{% elif post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}
-        </a>
-        <time class="archive-post-date" datetime="{{ postDate | htmlDateString }}">
-          {{ postDate | readableDate }}
-        </time>
-      </li>
-    {% endfor %}
-  </ul>
-{% endfor %}
+{% if currentMonth != null %}</ul>{% endif %}

--- a/archive.njk
+++ b/archive.njk
@@ -64,8 +64,8 @@ eleventyNavigation:
     {% if month != currentMonth %}
       {% if currentMonth != null %}</ul>{% endif %}
       <h3 class="archive-month">{{ monthNames[month] }}</h3>
-      <ul class="archive-posts">
       {% set currentMonth = month %}
+      <ul class="archive-posts">
     {% endif %}
     
     {# Display the post using the same pattern as postslist.njk #}

--- a/sass/index.scss
+++ b/sass/index.scss
@@ -391,3 +391,62 @@ a[href].direct-link:focus:visited,
   border-left-color: #B8956A; /* Warm tan accent */
   color: #F0E4D2; /* Sand/cream text */
 }
+
+/* Archive Page Styles */
+.archive-year {
+  font-size: 2em;
+  font-weight: 700;
+  color: var(--blue);
+  margin: 2em 0 1em 0;
+  border-bottom: 2px solid var(--lightgray);
+  padding-bottom: 0.5em;
+}
+
+.archive-year:first-of-type {
+  margin-top: 1em;
+}
+
+.archive-month {
+  font-size: 1.3em;
+  font-weight: 600;
+  color: var(--darkgray);
+  margin: 1.5em 0 0.8em 0;
+  padding-left: 1em;
+}
+
+.archive-posts {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 2em 2em;
+}
+
+.archive-post-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.5em 0;
+  border-bottom: 1px solid var(--lightgray);
+}
+
+.archive-post-item:last-child {
+  border-bottom: none;
+}
+
+.archive-post-link {
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--text);
+  flex-grow: 1;
+}
+
+.archive-post-link:hover {
+  color: var(--blue);
+  text-decoration: underline;
+}
+
+.archive-post-date {
+  font-size: 0.9em;
+  color: var(--darkgray);
+  margin-left: 1em;
+  white-space: nowrap;
+}


### PR DESCRIPTION
- Archive now displays posts grouped by year sections with month subsections
- Years and months are ordered newest-first for better navigation
- Posts within each month are sorted newest-first
- Added proper CSS styling for archive hierarchy
- Improves browsing experience for finding posts from specific time periods