### PR TITLE
Fix #114: sort out tags

### DIFF
--- a/_data/contentfulPosts.js
+++ b/_data/contentfulPosts.js
@@ -5,22 +5,36 @@ const renderRichText = require('../lib/renderRichText');
 function asDate(v) {
   if (!v) return null;
   const d = new Date(v);
-  return isNaN(d) ? null : d;
+  return Number.isNaN(d.getTime()) ? null : d;
 }
 
+// Accepts strings OR Contentful references (fields.slug/title or sys.id)
 function normalizeFieldTags(raw) {
   if (!raw) return [];
-  if (Array.isArray(raw)) return raw.filter(t => typeof t === 'string' && t.trim());
-  if (typeof raw === 'string') return [raw];
-  return [];
+  const arr = Array.isArray(raw) ? raw : [raw];
+
+  const pick = (t) => {
+    if (typeof t === 'string') return t;
+    if (t?.fields?.slug) return String(t.fields.slug);
+    if (t?.fields?.title) return String(t.fields.title);
+    if (t?.sys?.id) return String(t.sys.id);
+    return null;
+  };
+
+  return arr
+    .map(pick)
+    .filter(Boolean)
+    .map(s => s.trim().toLowerCase())
+    .filter(s => s.length > 0);
 }
 
+// Contentful “Tags” (UI feature): item.metadata.tags = [{ sys: { id } }, ...]
 function getMetadataTags(item) {
-  // Contentful "Tags" feature → item.metadata.tags = [{ sys: { id: 'tag-id' } }, ...]
   if (!item?.metadata?.tags) return [];
   return item.metadata.tags
     .map(t => t?.sys?.id)
-    .filter(Boolean);
+    .filter(Boolean)
+    .map(s => String(s).trim().toLowerCase());
 }
 
 module.exports = async () => {
@@ -28,39 +42,47 @@ module.exports = async () => {
     content_type: 'blogPost',
     order: '-fields.publishDate',
     include: 2,
-    limit: 1000
+    limit: 1000,
   });
 
-  const posts = res.items
+  const posts = (res.items || [])
     .filter(item => item?.fields?.slug)
     .map(item => {
       const f = item.fields;
 
+      // Merge & dedupe field-level tags and metadata tags
       const fieldTags = normalizeFieldTags(f.tags);
-      const metaTags = getMetadataTags(item);
+      const metaTags  = getMetadataTags(item);
       const tags = Array.from(new Set([...fieldTags, ...metaTags]));
 
+      // Prefer explicit publishDate, then sys.updatedAt, then now
       const date =
         asDate(f.publishDate) ||
         asDate(item.sys?.updatedAt) ||
         new Date();
 
+      const title = f.title || '';
+      const slug  = f.slug;
+      const description = f.description || '';
+      const content = f.content ? renderRichText(f.content) : '';
+
       return {
-        title: f.title,
-        slug: f.slug,
-        description: f.description || '',
-        tags,
+        title,
+        slug,
+        description,
+        tags,                           // lower-cased, trimmed
         featured: Boolean(f.featured),
-        content: f.content ? renderRichText(f.content) : '',
-        date,
-        url: `/posts/${f.slug}/`,
-        inputPath: `./posts/${f.slug}.md`,
+        content,                        // HTML string
+        date,                           // Date object
+        url: `/posts/${slug}/`,
+        // Hints for Eleventy/debugging (not written to disk; virtual templates will render)
+        inputPath: `./posts/${slug}.md`,
         data: {
-          title: f.title,
-          description: f.description || '',
+          title,
+          description,
           date,
-          tags
-        }
+          tags,
+        },
       };
     });
 

--- a/posts/posts.11ty.js
+++ b/posts/posts.11ty.js
@@ -1,44 +1,43 @@
 // posts/posts.11ty.js
 function normalizeTags(raw) {
-  if (!raw) return [];
-  if (Array.isArray(raw)) {
-    return raw
-      .map(t => {
-        if (typeof t === "string") return t.trim();
-        if (t?.fields?.slug) return String(t.fields.slug).trim();
-        if (t?.fields?.title) return String(t.fields.title).trim();
-        if (t?.sys?.id) return String(t.sys.id).trim();
-        return null;
-      })
-      .filter(Boolean);
-  }
-  if (typeof raw === "string") return [raw.trim()];
-  if (raw?.fields?.slug) return [String(raw.fields.slug).trim()];
-  if (raw?.fields?.title) return [String(raw.fields.title).trim()];
-  if (raw?.sys?.id) return [String(raw.sys.id).trim()];
-  return [];
+  const toVal = (t) => {
+    if (typeof t === "string") return t;
+    if (t?.fields?.slug) return String(t.fields.slug);
+    if (t?.fields?.title) return String(t.fields.title);
+    if (t?.sys?.id) return String(t.sys.id);
+    return null;
+  };
+
+  const arr = Array.isArray(raw) ? raw : [raw];
+  return arr
+    .map(toVal)
+    .filter(Boolean)
+    .map(s => s.trim().toLowerCase());
 }
 
 module.exports = class {
   data() {
     return {
+      // IMPORTANT: this must be on the root, not inside `pagination`
+      addAllPagesToCollections: true,
+
       pagination: {
-        data: "contentfulPosts",     // array from _data/contentfulPosts.js
+        data: "contentfulPosts", // array from _data/contentfulPosts.js
         size: 1,
         alias: "post",
-        addAllPagesToCollections: true, // ← critical: include every generated page in tag collections
       },
+
       permalink: ({ post }) => `/posts/${post.slug}/`,
       layout: "layouts/post.njk",
 
-      // static tag so Eleventy includes this template in tag collections at build time
-      tags: ["post"],
-
       eleventyComputed: {
         title: ({ post }) => post.title,
-        date: ({ post }) => post.date,
-        // visible user tags + hidden "post" tag
+        // Ensure Eleventy treats this as a date object if your mapper passed a string
+        date: ({ post }) => (post.date ? new Date(post.date) : undefined),
+
+        // Put every page into the 'post' collection, plus its Contentful tags (normalised)
         tags: ({ post }) => ["post", ...normalizeTags(post.tags)],
+
         description: ({ post }) => post.description || "",
       },
     };

--- a/tags.njk
+++ b/tags.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/base.njk
 pagination:
-  data: collections.tagList     # array of tag names from your tagList collection
+  data: collections.tagList        # array of tag names (already filtered to real tags)
   size: 1
   alias: tag
 permalink: /tags/{{ tag | slug }}/
@@ -9,15 +9,21 @@ eleventyComputed:
   title: Tagged “{{ tag }}”
 ---
 
+{% set tagged = collections[tag] or [] %}
+
 <h1>Tagged “{{ tag }}”</h1>
 
-<ul>
-{%- for item in collections[tag] | reverse -%}
-  <li>
-    <a href="{{ item.url | url }}">{{ item.data.title }}</a>
-    <small> — <time datetime="{{ item.date | htmlDateString }}">{{ item.date | readableDate }}</time></small>
-  </li>
-{%- endfor -%}
-</ul>
+{% if tagged.length %}
+  <ul class="postlist">
+  {%- for item in tagged | reverse -%}
+    <li class="postlist-item">
+      <time class="postlist-date" datetime="{{ item.date | htmlDateString }}">{{ item.date | readableDate }}</time>
+      <a class="postlist-link" href="{{ item.url | url }}">{{ item.data.title }}</a>
+    </li>
+  {%- endfor -%}
+  </ul>
+{% else %}
+  <p>No posts found for this tag.</p>
+{% endif %}
 
 <p><a href="/tags/">All tags</a></p>


### PR DESCRIPTION
This PR addresses issue #114 by fixing how tags are handled and displayed:

- Normalized tags in `_data/contentfulPosts.js` (lower-cased, trimmed, deduped from both field + metadata sources).
- Updated `posts/posts.11ty.js` to expose tags, title, and date through `eleventyComputed`, ensuring posts are registered in tag collections.
- Improved `tags.njk` to actually list posts for each tag, with graceful handling when no posts exist.

Result: Tag pages (e.g. /tags/cardiacs/) now correctly show all posts associated with that tag.
